### PR TITLE
Change the depth remainder style from '15.2ft To Go' to '15.2 Feet To Go'

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -64,7 +64,7 @@ function displayDepth() {
   updatePercentage(
     100 * (waterLevels.currentDepth / waterLevels.fullDepth),
     100 * (waterLevels.currentDepth / waterLevels.maxDepth),
-    round((waterLevels.fullDepth - waterLevels.currentDepth), 1) + 'ft To Go'
+    round((waterLevels.fullDepth - waterLevels.currentDepth), 1) + ' ft. To Go'
   );
 }
 

--- a/js/script.js
+++ b/js/script.js
@@ -64,7 +64,7 @@ function displayDepth() {
   updatePercentage(
     100 * (waterLevels.currentDepth / waterLevels.fullDepth),
     100 * (waterLevels.currentDepth / waterLevels.maxDepth),
-    round((waterLevels.fullDepth - waterLevels.currentDepth), 1) + ' ft. To Go'
+    round((waterLevels.fullDepth - waterLevels.currentDepth), 1) + ' Feet To Go'
   );
 }
 


### PR DESCRIPTION
This is just personal preference, so feel free to reject, but this simply spells out the unit and capitalizes it (to match the rest of the text).
